### PR TITLE
adds no signatures found handler

### DIFF
--- a/lib/signore/cli.rb
+++ b/lib/signore/cli.rb
@@ -16,7 +16,7 @@ module Signore
 
     def run(input: $stdin)
       case action
-      when 'prego'  then puts retrieve_sig
+      when 'prego'  then prego
       when 'pronto' then puts create_sig_from(input)
       else abort 'usage: signore prego|pronto [tag, …]'
       end
@@ -25,6 +25,15 @@ module Signore
     private_attr_reader :repo, :settings
 
     private
+
+    def prego
+      sig = repo.find(tags: tags)
+      puts case
+           when repo.empty? then 'No signatures found.'
+           when sig.empty?  then "Sadly no signatures are tagged #{tags}."
+           else sig
+           end
+    end
 
     def create_sig_from(input)
       SigFromStream.sig_from(input, tags: tags).tap { |sig| repo << sig }

--- a/lib/signore/repo.rb
+++ b/lib/signore/repo.rb
@@ -30,6 +30,10 @@ module Signore
 
     private_attr_reader :path, :sig_finder
 
+    def empty?
+      sigs.empty?
+    end
+
     private
 
     def persist

--- a/lib/signore/signature.rb
+++ b/lib/signore/signature.rb
@@ -23,6 +23,10 @@ module Signore
       squeezed + meta_for(squeezed)
     end
 
+    def empty?
+      to_s.empty?
+    end
+
     private
 
     def indent_size_for(text)

--- a/lib/signore/tags.rb
+++ b/lib/signore/tags.rb
@@ -8,5 +8,9 @@ module Signore
       sig_tags ||= []
       (required & sig_tags) == required and (forbidden & sig_tags).empty?
     end
+
+    def to_s
+      (required + forbidden.collect { |tag| '~' + tag }).join(' ')
+    end
   end
 end

--- a/test/fixtures/nosignatures.yml
+++ b/test/fixtures/nosignatures.yml
@@ -1,0 +1,2 @@
+---
+signatures: []

--- a/test/signore/cli_test.rb
+++ b/test/signore/cli_test.rb
@@ -37,6 +37,22 @@ module Signore
                                                   [Gary Barnes, asr]
           end
         end
+
+        it 'tells the user if no signatures are found' do
+          path = Pathname.new('test/fixtures/nosignatures.yml')
+          repo = Repo.new(path: path)
+          args = %w(prego)
+          out = capture_io { CLI.new(args, repo: repo).run }.first
+          _(out).must_include 'No signatures found.'
+        end
+
+        it 'tells the user if no signatures with selected tag are found' do
+          path = Pathname.new('test/fixtures/signatures.yml')
+          repo = Repo.new(path: path)
+          args = %w(prego esse ~percipi)
+          out = capture_io { CLI.new(args, repo: repo).run }.first
+          _(out).must_include 'Sadly no signatures are tagged esse ~percipi.'
+        end
       end
 
       describe 'pronto' do


### PR DESCRIPTION
How about giving the user info that there are no signatures found?
I solved this as a bug to an older version of signore I had on my hd. I see that now nothing is returned, so maybe it is the most wanted behavior. It's you're choice :-)